### PR TITLE
GH actions index with scip-go

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -9,7 +9,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/go-diff-patch'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
+    container: sourcegraph/scip-go
     steps:
       # Setup
       - name: Checkout


### PR DESCRIPTION
Replace lsif code intel builds with scip in github actions

[_Created by Sourcegraph batch change `christine/GithubActions-updateSGTest`._](https://demo.sourcegraph.com/users/christine/batch-changes/GithubActions-updateSGTest)